### PR TITLE
Feature: Refactor email service to use EJS templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "bcryptjs": "^3.0.2",
                 "cors": "^2.8.5",
                 "dotenv": "^16.5.0",
+                "ejs": "^3.1.9",
                 "express": "^4.17.1",
                 "jsonwebtoken": "^9.0.2",
                 "nodemailer": "^7.0.3",
@@ -36,6 +37,21 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/anymatch": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -56,11 +72,16 @@
             "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
             "license": "MIT"
         },
+        "node_modules/async": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+            "license": "MIT"
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/bcrypt": {
@@ -127,7 +148,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -191,6 +211,43 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chalk/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/chokidar": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -216,11 +273,28 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "license": "MIT"
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/content-disposition": {
@@ -341,6 +415,21 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
             "license": "MIT"
         },
+        "node_modules/ejs": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+            "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "jake": "^10.8.5"
+            },
+            "bin": {
+                "ejs": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/encodeurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -439,6 +528,36 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/filelist": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+            "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "minimatch": "^5.0.1"
+            }
+        },
+        "node_modules/filelist/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/filelist/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/fill-range": {
@@ -706,6 +825,24 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/jake": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+            "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "async": "^3.2.3",
+                "chalk": "^4.0.2",
+                "filelist": "^1.0.4",
+                "minimatch": "^3.1.2"
+            },
+            "bin": {
+                "jake": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/jsonwebtoken": {
             "version": "9.0.2",
             "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -870,7 +1007,6 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
+        "ejs": "^3.1.9",
         "express": "^4.17.1",
         "jsonwebtoken": "^9.0.2",
         "nodemailer": "^7.0.3",

--- a/services/email.service.js
+++ b/services/email.service.js
@@ -1,6 +1,8 @@
 // Archivo: services/emailService.js
 
 const nodemailer = require('nodemailer');
+const ejs = require('ejs');
+const path = require('path');
 
 // Configuración del "Transportador" que enviará los emails usando Gmail.
 // Toma las credenciales de tu archivo .env
@@ -12,6 +14,18 @@ const transporter = nodemailer.createTransport({
   },
 });
 
+// Helper functions for EJS templates
+const formatCurrency = (amount) => {
+  return new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' }).format(amount);
+};
+
+const formatDate = (dateString) => {
+  return new Date(dateString).toLocaleDateString('es-CL', { year: 'numeric', month: 'long', day: 'numeric' });
+};
+
+const formatTime = (timeString) => {
+  return timeString.substring(0, 5);
+};
 
 // --- FUNCIÓN 1: EMAIL DE SOLICITUD DE RESERVA RECIBIDA (ACTUALIZADA) ---
 /**
@@ -25,35 +39,15 @@ const enviarEmailSolicitudRecibida = async (reserva) => {
       from: `"Reservas Apialan" <${process.env.EMAIL_USER}>`,
       to: reserva.cliente_email,
       subject: `📄 Solicitud de Reserva Recibida (ID: ${reserva.id})`,
-      html: `
-        <div style="font-family: Arial, sans-serif; color: #333; line-height: 1.6;">
-          <h2 style="color: #4f46e5;">¡Hola, ${reserva.cliente_nombre}!</h2>
-          <p>Hemos recibido tu solicitud de reserva y hemos guardado tu cupo temporalmente. Para confirmar tu reserva de forma definitiva, por favor realiza el pago.</p>
-          
-          <h3 style="border-bottom: 2px solid #e0e7ff; padding-bottom: 5px; color: #3730a3;">Instrucciones de Pago</h3>
-          <p>Puedes realizar una transferencia bancaria por un total de <strong>${new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' }).format(reserva.costo_total)}</strong> a la siguiente cuenta:</p>
-          
-          <table style="width: 100%; border-collapse: collapse; margin-top: 15px;">
-            <tr style="background-color: #f8f9fa;"><td style="padding: 10px; border: 1px solid #ddd;"><strong>Banco:</strong></td><td style="padding: 10px; border: 1px solid #ddd;">Banco Estado</td></tr>
-            <tr><td style="padding: 10px; border: 1px solid #ddd;"><strong>Tipo de Cuenta:</strong></td><td style="padding: 10px; border: 1px solid #ddd;">Corriente</td></tr>
-            <tr style="background-color: #f8f9fa;"><td style="padding: 10px; border: 1px solid #ddd;"><strong>Número de Cuenta:</strong></td><td style="padding: 10px; border: 1px solid #ddd;">55100101199</td></tr>
-            <tr><td style="padding: 10px; border: 1px solid #ddd;"><strong>Nombre:</strong></td><td style="padding: 10px; border: 1px solid #ddd;">Asociación de prestadores de servicios, industriales y artesanos de Los Ángeles.</td></tr>
-            <tr style="background-color: #f8f9fa;"><td style="padding: 10px; border: 1px solid #ddd;"><strong>RUT:</strong></td><td style="padding: 10px; border: 1px solid #ddd;">70.382.000-K</td></tr>
-            <tr><td style="padding: 10px; border: 1px solid #ddd;"><strong>Email:</strong></td><td style="padding: 10px; border: 1px solid #ddd;">cie@apialan.cl</td></tr>
-          </table>
-
-          <p style="margin-top: 20px;">Una vez realizado el pago, por favor envía el comprobante a nuestro correo <strong>cie@apialan.cl</strong> para confirmar tu reserva. Tienes un plazo de 24 horas para realizar el pago, de lo contrario, la solicitud podría ser cancelada.</p>
-          <hr>
-          <h3>Detalles de tu Solicitud:</h3>
-          <ul>
-            <li><strong>ID de Reserva:</strong> ${reserva.id}</li>
-            <li><strong>Salón:</strong> ${reserva.nombre_espacio}</li>
-            <li><strong>Fecha:</strong> ${new Date(reserva.fecha_reserva).toLocaleDateString('es-CL', { year: 'numeric', month: 'long', day: 'numeric' })}</li>
-            <li><strong>Horario:</strong> ${reserva.hora_inicio.substring(0, 5)} - ${reserva.hora_termino.substring(0, 5)}</li>
-          </ul>
-          <p>Saludos,<br>El equipo de Apialan AG</p>
-        </div>
-      `,
+      html: await ejs.renderFile(
+        path.join(__dirname, '../views/emails/solicitudRecibida.ejs'),
+        {
+          reserva: reserva,
+          formatCurrency: formatCurrency,
+          formatDate: formatDate,
+          formatTime: formatTime
+        }
+      ),
     };
 
     await transporter.sendMail(mailOptions);
@@ -71,22 +65,15 @@ const enviarEmailReservaConfirmada = async (reserva) => {
       from: `"Reservas Apialan" <${process.env.EMAIL_USER}>`,
       to: reserva.cliente_email,
       subject: `✅ ¡Tu reserva en Apialan está Confirmada! (ID: ${reserva.id})`,
-      html: `
-        <div style="font-family: Arial, sans-serif; color: #333; line-height: 1.6;">
-          <h2>¡Hola, ${reserva.cliente_nombre}!</h2>
-          <p>¡Tu reserva ha sido confirmada exitosamente! Hemos recibido tu pago y tu cupo está asegurado. ¡Te esperamos!</p>
-          <hr>
-          <h3>Detalles de tu Reserva:</h3>
-          <ul>
-            <li><strong>ID de Reserva:</strong> ${reserva.id}</li>
-            <li><strong>Salón:</strong> ${reserva.nombre_espacio}</li>
-            <li><strong>Fecha:</strong> ${new Date(reserva.fecha_reserva).toLocaleDateString('es-CL', { year: 'numeric', month: 'long', day: 'numeric' })}</li>
-            <li><strong>Horario:</strong> ${reserva.hora_inicio.substring(0, 5)} - ${reserva.hora_termino.substring(0, 5)}</li>
-          </ul>
-          <p>Si necesitas hacer cambios o tienes alguna consulta, no dudes en contactarnos.</p>
-          <p>Saludos,<br>El equipo de Apialan AG</p>
-        </div>
-      `,
+      html: await ejs.renderFile(
+        path.join(__dirname, '../views/emails/reservaConfirmada.ejs'),
+        {
+          reserva: reserva,
+          formatCurrency: formatCurrency,
+          formatDate: formatDate,
+          formatTime: formatTime
+        }
+      ),
     };
     await transporter.sendMail(mailOptions);
     console.log(`Email de confirmación final enviado a ${reserva.cliente_email}`);
@@ -103,21 +90,15 @@ const enviarEmailCancelacionCliente = async (reserva) => {
       from: `"Reservas Apialan" <${process.env.EMAIL_USER}>`,
       to: reserva.cliente_email,
       subject: `✅ Confirmación de Cancelación de Reserva (ID: ${reserva.id})`,
-      html: `
-        <div style="font-family: Arial, sans-serif; color: #333; line-height: 1.6;">
-          <h2>¡Hola, ${reserva.cliente_nombre}!</h2>
-          <p>Confirmamos que, <strong>según tu solicitud</strong>, hemos procesado la cancelación de tu reserva.</p>
-          <hr>
-          <h3>Detalles de la Reserva Cancelada:</h3>
-          <ul>
-            <li><strong>ID de Reserva:</strong> ${reserva.id}</li>
-            <li><strong>Salón:</strong> ${reserva.nombre_espacio}</li>
-            <li><strong>Fecha:</strong> ${new Date(reserva.fecha_reserva).toLocaleDateString('es-CL', { year: 'numeric', month: 'long', day: 'numeric' })}</li>
-          </ul>
-          <p>El espacio ha sido liberado. Esperamos verte de nuevo pronto.</p>
-          <p>Saludos,<br>El equipo de Apialan AG</p>
-        </div>
-      `,
+      html: await ejs.renderFile(
+        path.join(__dirname, '../views/emails/cancelacionCliente.ejs'),
+        {
+          reserva: reserva,
+          formatCurrency: formatCurrency,
+          formatDate: formatDate,
+          formatTime: formatTime
+        }
+      ),
     };
     await transporter.sendMail(mailOptions);
     console.log(`Email de cancelación (solicitada por cliente) enviado a ${reserva.cliente_email}`);
@@ -134,21 +115,15 @@ const enviarEmailCancelacionAdmin = async (reserva) => {
       from: `"Reservas Apialan" <${process.env.EMAIL_USER}>`,
       to: reserva.cliente_email,
       subject: `❌ Notificación de Cancelación de Reserva (ID: ${reserva.id})`,
-      html: `
-        <div style="font-family: Arial, sans-serif; color: #333; line-height: 1.6;">
-          <h2>¡Hola, ${reserva.cliente_nombre}!</h2>
-          <p>Te informamos que tu reserva ha sido cancelada por un administrador.</p>
-          <hr>
-          <h3>Detalles de la Reserva Cancelada:</h3>
-          <ul>
-            <li><strong>ID de Reserva:</strong> ${reserva.id}</li>
-            <li><strong>Salón:</strong> ${reserva.nombre_espacio}</li>
-            <li><strong>Fecha:</strong> ${new Date(reserva.fecha_reserva).toLocaleDateString('es-CL', { year: 'numeric', month: 'long', day: 'numeric' })}</li>
-          </ul>
-          <p>Si tienes alguna duda sobre esta cancelación, por favor, ponte en contacto con nosotros.</p>
-          <p>Saludos,<br>El equipo de Apialan AG</p>
-        </div>
-      `,
+      html: await ejs.renderFile(
+        path.join(__dirname, '../views/emails/cancelacionAdmin.ejs'),
+        {
+          reserva: reserva,
+          formatCurrency: formatCurrency,
+          formatDate: formatDate,
+          formatTime: formatTime
+        }
+      ),
     };
     await transporter.sendMail(mailOptions);
     console.log(`Email de cancelación (iniciada por admin) enviado a ${reserva.cliente_email}`);

--- a/views/emails/cancelacionAdmin.ejs
+++ b/views/emails/cancelacionAdmin.ejs
@@ -1,0 +1,13 @@
+<div style="font-family: Arial, sans-serif; color: #333; line-height: 1.6;">
+  <h2>¡Hola, <%= reserva.cliente_nombre %>!</h2>
+  <p>Te informamos que tu reserva ha sido cancelada por un administrador.</p>
+  <hr>
+  <h3>Detalles de la Reserva Cancelada:</h3>
+  <ul>
+    <li><strong>ID de Reserva:</strong> <%= reserva.id %></li>
+    <li><strong>Salón:</strong> <%= reserva.nombre_espacio %></li>
+    <li><strong>Fecha:</strong> <%= formatDate(reserva.fecha_reserva) %></li>
+  </ul>
+  <p>Si tienes alguna duda sobre esta cancelación, por favor, ponte en contacto con nosotros.</p>
+  <p>Saludos,<br>El equipo de Apialan AG</p>
+</div>

--- a/views/emails/cancelacionCliente.ejs
+++ b/views/emails/cancelacionCliente.ejs
@@ -1,0 +1,13 @@
+<div style="font-family: Arial, sans-serif; color: #333; line-height: 1.6;">
+  <h2>¡Hola, <%= reserva.cliente_nombre %>!</h2>
+  <p>Confirmamos que, <strong>según tu solicitud</strong>, hemos procesado la cancelación de tu reserva.</p>
+  <hr>
+  <h3>Detalles de la Reserva Cancelada:</h3>
+  <ul>
+    <li><strong>ID de Reserva:</strong> <%= reserva.id %></li>
+    <li><strong>Salón:</strong> <%= reserva.nombre_espacio %></li>
+    <li><strong>Fecha:</strong> <%= formatDate(reserva.fecha_reserva) %></li>
+  </ul>
+  <p>El espacio ha sido liberado. Esperamos verte de nuevo pronto.</p>
+  <p>Saludos,<br>El equipo de Apialan AG</p>
+</div>

--- a/views/emails/reservaConfirmada.ejs
+++ b/views/emails/reservaConfirmada.ejs
@@ -1,0 +1,14 @@
+<div style="font-family: Arial, sans-serif; color: #333; line-height: 1.6;">
+  <h2>¡Hola, <%= reserva.cliente_nombre %>!</h2>
+  <p>¡Tu reserva ha sido confirmada exitosamente! Hemos recibido tu pago y tu cupo está asegurado. ¡Te esperamos!</p>
+  <hr>
+  <h3>Detalles de tu Reserva:</h3>
+  <ul>
+    <li><strong>ID de Reserva:</strong> <%= reserva.id %></li>
+    <li><strong>Salón:</strong> <%= reserva.nombre_espacio %></li>
+    <li><strong>Fecha:</strong> <%= formatDate(reserva.fecha_reserva) %></li>
+    <li><strong>Horario:</strong> <%= formatTime(reserva.hora_inicio) %> - <%= formatTime(reserva.hora_termino) %></li>
+  </ul>
+  <p>Si necesitas hacer cambios o tienes alguna consulta, no dudes en contactarnos.</p>
+  <p>Saludos,<br>El equipo de Apialan AG</p>
+</div>

--- a/views/emails/solicitudRecibida.ejs
+++ b/views/emails/solicitudRecibida.ejs
@@ -1,0 +1,27 @@
+<div style="font-family: Arial, sans-serif; color: #333; line-height: 1.6;">
+  <h2 style="color: #4f46e5;">¡Hola, <%= reserva.cliente_nombre %>!</h2>
+  <p>Hemos recibido tu solicitud de reserva y hemos guardado tu cupo temporalmente. Para confirmar tu reserva de forma definitiva, por favor realiza el pago.</p>
+
+  <h3 style="border-bottom: 2px solid #e0e7ff; padding-bottom: 5px; color: #3730a3;">Instrucciones de Pago</h3>
+  <p>Puedes realizar una transferencia bancaria por un total de <strong><%= formatCurrency(reserva.costo_total) %></strong> a la siguiente cuenta:</p>
+
+  <table style="width: 100%; border-collapse: collapse; margin-top: 15px;">
+    <tr style="background-color: #f8f9fa;"><td style="padding: 10px; border: 1px solid #ddd;"><strong>Banco:</strong></td><td style="padding: 10px; border: 1px solid #ddd;">Banco Estado</td></tr>
+    <tr><td style="padding: 10px; border: 1px solid #ddd;"><strong>Tipo de Cuenta:</strong></td><td style="padding: 10px; border: 1px solid #ddd;">Corriente</td></tr>
+    <tr style="background-color: #f8f9fa;"><td style="padding: 10px; border: 1px solid #ddd;"><strong>Número de Cuenta:</strong></td><td style="padding: 10px; border: 1px solid #ddd;">55100101199</td></tr>
+    <tr><td style="padding: 10px; border: 1px solid #ddd;"><strong>Nombre:</strong></td><td style="padding: 10px; border: 1px solid #ddd;">Asociación de prestadores de servicios, industriales y artesanos de Los Ángeles.</td></tr>
+    <tr style="background-color: #f8f9fa;"><td style="padding: 10px; border: 1px solid #ddd;"><strong>RUT:</strong></td><td style="padding: 10px; border: 1px solid #ddd;">70.382.000-K</td></tr>
+    <tr><td style="padding: 10px; border: 1px solid #ddd;"><strong>Email:</strong></td><td style="padding: 10px; border: 1px solid #ddd;">cie@apialan.cl</td></tr>
+  </table>
+
+  <p style="margin-top: 20px;">Una vez realizado el pago, por favor envía el comprobante a nuestro correo <strong>cie@apialan.cl</strong> para confirmar tu reserva. Tienes un plazo de 24 horas para realizar el pago, de lo contrario, la solicitud podría ser cancelada.</p>
+  <hr>
+  <h3>Detalles de tu Solicitud:</h3>
+  <ul>
+    <li><strong>ID de Reserva:</strong> <%= reserva.id %></li>
+    <li><strong>Salón:</strong> <%= reserva.nombre_espacio %></li>
+    <li><strong>Fecha:</strong> <%= formatDate(reserva.fecha_reserva) %></li>
+    <li><strong>Horario:</strong> <%= formatTime(reserva.hora_inicio) %> - <%= formatTime(reserva.hora_termino) %></li>
+  </ul>
+  <p>Saludos,<br>El equipo de Apialan AG</p>
+</div>


### PR DESCRIPTION
- I installed EJS and created a views/emails directory.
- I created EJS templates for all four email types: solicitudRecibida, reservaConfirmada, cancelacionCliente, and cancelacionAdmin.
- I refactored services/email.service.js to render HTML content from these EJS templates, passing reservation data and formatting helpers.
- This change improves maintainability and separation of concerns for email content.