### PR TITLE
Fix: Exclude cancelled reservations from public availability query

### DIFF
--- a/routes/reservas.routes.js
+++ b/routes/reservas.routes.js
@@ -22,6 +22,11 @@ router.get('/', async (req, res) => {
     const queryParams = [];
     const whereClauses = [];
     let paramIndex = 1;
+
+    // Add the mandatory filter for reservation status
+    // No parameters needed for this part of the clause, so paramIndex is not incremented here.
+    whereClauses.push(`estado_reserva NOT IN ('cancelada_por_cliente', 'cancelada_por_admin')`);
+
     if (espacio_id) { whereClauses.push(`espacio_id = $${paramIndex++}`); queryParams.push(espacio_id); }
     if (fecha) { whereClauses.push(`fecha_reserva = $${paramIndex++}`); queryParams.push(fecha); }
     if (mes) {


### PR DESCRIPTION
- Modified the public GET / endpoint in routes/reservas.routes.js.
- Added a mandatory filter to the database query to ensure that reservations with estado_reserva 'cancelada_por_cliente' or 'cancelada_por_admin' are not returned.
- This corrects a bug where cancelled reservations could appear as unavailable slots in public availability checks.