### PR TITLE
Here's what I did to help debug the GET /reservas endpoint:

### DIFF
--- a/routes/reservas.routes.js
+++ b/routes/reservas.routes.js
@@ -38,7 +38,10 @@ router.get('/', async (req, res) => {
     }
     if (whereClauses.length > 0) { queryText += ' WHERE ' + whereClauses.join(' AND '); }
     queryText += ' ORDER BY fecha_reserva ASC, hora_inicio ASC;';
+    console.log('Executing query for GET /reservas:', queryText);
+    console.log('Query parameters for GET /reservas:', queryParams);
     const resultado = await pool.query(queryText, queryParams);
+    console.log(`GET /reservas: Found ${resultado.rowCount} rows. First few results (if any):`, JSON.stringify(resultado.rows.slice(0, 5), null, 2)); // Log first 5 rows
     res.status(200).json(resultado.rows);
   } catch (err) {
     console.error("Error al obtener las reservas públicas:", err.message);


### PR DESCRIPTION
- I added some console logs within the `public GET /reservas` route handler in `routes/reservas.routes.js`.
- These logs will show the exact SQL query being executed, the parameters being used, and a sample of the raw data returned from the database.
- This should help us figure out why 'pendiente' reservations might not be correctly appearing as unavailable slots.