### PR TITLE
Fix: Incluir id en la consulta de detalles del espacio

### DIFF
--- a/routes/reservas.routes.js
+++ b/routes/reservas.routes.js
@@ -84,7 +84,7 @@ router.post('/', async (req, res) => {
       return res.status(409).json({ error: 'El espacio ya está reservado para el horario solicitado.' });
     }
     
-    const espacioResult = await pool.query('SELECT nombre, precio_por_hora, precio_socio_por_hora FROM "espacios" WHERE id = $1', [espacio_id]);
+    const espacioResult = await pool.query('SELECT id, nombre, precio_por_hora, precio_socio_por_hora FROM "espacios" WHERE id = $1', [espacio_id]);
     if (espacioResult.rowCount === 0) {
       return res.status(404).json({ error: `Espacio con id ${espacio_id} no encontrado.` });
     }


### PR DESCRIPTION
Se modificó la consulta SQL en `routes/reservas.routes.js` que recupera los detalles del espacio para seleccionar también la columna `id`.

Esto asegura que el objeto `espacio` pasado a `calcularCostoTotal` contenga la propiedad `id`, corrigiendo un error en los logs donde se mostraba "espacio con ID: desconocido" y permitiendo que `precio_socio_por_hora` se procese correctamente si el `id` faltante era la causa de que el objeto `espacio` no se construyera adecuadamente.