### PR TITLE
feat: Enviar notificación de nueva reserva al administrador

### DIFF
--- a/routes/reservas.routes.js
+++ b/routes/reservas.routes.js
@@ -8,7 +8,8 @@ const {
   enviarEmailSolicitudRecibida,
   enviarEmailReservaConfirmada,
   enviarEmailCancelacionCliente, 
-  enviarEmailCancelacionAdmin 
+  enviarEmailCancelacionAdmin,
+  enviarEmailNotificacionAdminNuevaSolicitud // Importar la nueva función
 } = require('../services/email.service');
 const { validarHorasSocio, calcularCostoTotal } = require('../services/booking.service.js');
 const { parseISO, format, isValid } = require('date-fns');
@@ -112,6 +113,15 @@ router.post('/', async (req, res) => {
     
     reservaCreada.nombre_espacio = espacio.nombre;
     await enviarEmailSolicitudRecibida(reservaCreada);
+
+    // Enviar notificación al administrador
+    const adminEmail = process.env.ADMIN_EMAIL_NOTIFICATIONS; // Asegúrate de tener esta variable de entorno
+    if (adminEmail) {
+      await enviarEmailNotificacionAdminNuevaSolicitud(reservaCreada, adminEmail);
+    } else {
+      console.warn('ADMIN_EMAIL_NOTIFICATIONS no está configurado. No se enviará correo al administrador.');
+    }
+
     res.status(201).json({ mensaje: 'Solicitud de reserva recibida. Por favor, realiza el pago para confirmar.', reserva: reservaCreada });
 
   } catch (err) {

--- a/services/email.service.js
+++ b/services/email.service.js
@@ -139,4 +139,48 @@ module.exports = {
   enviarEmailReservaConfirmada,
   enviarEmailCancelacionCliente,
   enviarEmailCancelacionAdmin,
+  enviarEmailNotificacionAdminNuevaSolicitud, // Exportar la nueva función
+};
+
+// --- FUNCIÓN 5: EMAIL DE NOTIFICACIÓN AL ADMINISTRADOR SOBRE NUEVA SOLICITUD ---
+/**
+ * Envía un email de notificación al administrador sobre una nueva solicitud de reserva.
+ * @param {object} reserva - El objeto de la reserva creada.
+ * @param {string} adminEmail - La dirección de correo del administrador.
+ */
+const enviarEmailNotificacionAdminNuevaSolicitud = async (reserva, adminEmail) => {
+  try {
+    // Podríamos crear una plantilla EJS específica para este correo si el formato es complejo,
+    // o construir un HTML simple directamente aquí. Por simplicidad, usaremos un texto/html básico.
+    const detallesReserva = `
+      <p>Se ha recibido una nueva solicitud de reserva con los siguientes detalles:</p>
+      <ul>
+        <li><strong>ID Reserva:</strong> ${reserva.id}</li>
+        <li><strong>Espacio:</strong> ${reserva.nombre_espacio || 'No especificado'}</li>
+        <li><strong>Cliente:</strong> ${reserva.cliente_nombre}</li>
+        <li><strong>Email Cliente:</strong> ${reserva.cliente_email}</li>
+        <li><strong>Teléfono Cliente:</strong> ${reserva.cliente_telefono || 'No especificado'}</li>
+        <li><strong>Fecha:</strong> ${formatDate(reserva.fecha_reserva)}</li>
+        <li><strong>Hora Inicio:</strong> ${formatTime(reserva.hora_inicio)}</li>
+        <li><strong>Hora Término:</strong> ${formatTime(reserva.hora_termino)}</li>
+        <li><strong>Costo Total:</strong> ${formatCurrency(reserva.costo_total)}</li>
+        <li><strong>Notas Adicionales:</strong> ${reserva.notas_adicionales || 'Ninguna'}</li>
+        <li><strong>Socio ID:</strong> ${reserva.socio_id || 'No aplica'}</li>
+      </ul>
+      <p>Por favor, revisa el panel de administración para más detalles o para confirmar la reserva una vez recibido el pago.</p>
+    `;
+
+    const mailOptions = {
+      from: `"Notificaciones Apialan" <${process.env.EMAIL_USER}>`,
+      to: adminEmail, // Enviar al correo del administrador
+      subject: `📢 Nueva Solicitud de Reserva Recibida - ID: ${reserva.id}`,
+      html: detallesReserva,
+    };
+
+    await transporter.sendMail(mailOptions);
+    console.log(`Email de notificación de nueva solicitud enviado a ${adminEmail} para reserva ID: ${reserva.id}`);
+  } catch (error) {
+    console.error(`Error al enviar email de notificación al admin para reserva ${reserva.id}:`, error);
+    // Considerar no lanzar el error para no afectar el flujo principal si solo falla el correo al admin
+  }
 };


### PR DESCRIPTION
- Añade función a EmailService para enviar un correo de notificación al administrador con los detalles de una nueva solicitud de reserva.
- Actualiza la ruta POST /reservas para llamar a esta nueva función después de enviar el correo de solicitud al cliente.
- La dirección de correo del administrador se lee desde la variable de entorno ADMIN_EMAIL_NOTIFICATIONS.