### PR TITLE
feat: Autorelleno de datos para socios validados

### DIFF
--- a/routes/socios.routes.js
+++ b/routes/socios.routes.js
@@ -24,7 +24,7 @@ router.post('/validar', async (req, res) => {
     //    - REPLACE(..., '-', '') quita los guiones del resultado anterior.
     //    - LOWER(...) convierte todo a minúsculas.
     const socioResult = await pool.query(
-      `SELECT id, nombre_completo, rut, estado 
+      `SELECT id, nombre_completo, rut, estado, email
        FROM socios 
        WHERE LOWER(REPLACE(REPLACE(rut, '.', ''), '-', '')) = $1 AND estado = 'activo'`,
       [rutLimpioUsuario] // Comparamos contra el RUT limpio del usuario
@@ -39,6 +39,7 @@ router.post('/validar', async (req, res) => {
       id: socio.id,
       nombre_completo: socio.nombre_completo,
       rut: socio.rut, // Devolvemos el RUT original formateado
+      email: socio.email, // Devolvemos el email del socio
     });
 
   } catch (error) {


### PR DESCRIPTION
- Modifica la ruta POST /socios/validar para que devuelva el nombre_completo y el email del socio.
- Prepara el backend para la funcionalidad de autorelleno de datos de socios en el formulario de reserva del frontend.

Se requiere la adición manual de la columna 'email' VARCHAR(255) a la tabla 'socios'.