### PR TITLE
fix: Corregir visualización de costos en correo admin y error en esta…

### DIFF
--- a/routes/admin.routes.js
+++ b/routes/admin.routes.js
@@ -157,11 +157,13 @@ router.get('/stats', async (req, res) => {
   try {
     // Consultas para los KPIs
     const reservasHoyQuery = pool.query(`SELECT COUNT(*) FROM "reservas" WHERE fecha_reserva = CURRENT_DATE`);
-    const ingresosMesQuery = pool.query(`SELECT SUM(costo_total) as total FROM "reservas" WHERE estado_reserva IN ('confirmada', 'pagado') AND DATE_TRUNC('month', fecha_reserva) = DATE_TRUNC('month', CURRENT_DATE)`);
+    // Actualizado a costo_total_historico
+    const ingresosMesQuery = pool.query(`SELECT SUM(costo_total_historico) as total FROM "reservas" WHERE estado_reserva IN ('confirmada', 'pagado') AND DATE_TRUNC('month', fecha_reserva) = DATE_TRUNC('month', CURRENT_DATE)`);
 
     // Consultas para los Gráficos
     const reservasPorSalonQuery = pool.query(`SELECT e.nombre, COUNT(r.id) as cantidad FROM "reservas" r JOIN "espacios" e ON r.espacio_id = e.id GROUP BY e.nombre`);
-    const ingresosMesesQuery = pool.query(`SELECT TO_CHAR(DATE_TRUNC('month', fecha_reserva), 'YYYY-MM') as mes, SUM(costo_total) as ingresos FROM "reservas" WHERE fecha_reserva >= DATE_TRUNC('month', CURRENT_DATE) - INTERVAL '5 months' AND estado_reserva IN ('confirmada', 'pagado') GROUP BY DATE_TRUNC('month', fecha_reserva) ORDER BY mes ASC`);
+    // Actualizado a costo_total_historico
+    const ingresosMesesQuery = pool.query(`SELECT TO_CHAR(DATE_TRUNC('month', fecha_reserva), 'YYYY-MM') as mes, SUM(costo_total_historico) as ingresos FROM "reservas" WHERE fecha_reserva >= DATE_TRUNC('month', CURRENT_DATE) - INTERVAL '5 months' AND estado_reserva IN ('confirmada', 'pagado') GROUP BY DATE_TRUNC('month', fecha_reserva) ORDER BY mes ASC`);
     
     // --- INICIO DE NUEVAS CONSULTAS ---
 

--- a/services/email.service.js
+++ b/services/email.service.js
@@ -163,7 +163,9 @@ const enviarEmailNotificacionAdminNuevaSolicitud = async (reserva, adminEmail) =
         <li><strong>Fecha:</strong> ${formatDate(reserva.fecha_reserva)}</li>
         <li><strong>Hora Inicio:</strong> ${formatTime(reserva.hora_inicio)}</li>
         <li><strong>Hora Término:</strong> ${formatTime(reserva.hora_termino)}</li>
-        <li><strong>Costo Total:</strong> ${formatCurrency(reserva.costo_total)}</li>
+        <li><strong>Neto:</strong> ${formatCurrency(reserva.costo_neto_historico)}</li>
+        <li><strong>IVA (19%):</strong> ${formatCurrency(reserva.costo_iva_historico)}</li>
+        <li><strong>Total:</strong> ${formatCurrency(reserva.costo_total_historico)}</li>
         <li><strong>Notas Adicionales:</strong> ${reserva.notas_adicionales || 'Ninguna'}</li>
         <li><strong>Socio ID:</strong> ${reserva.socio_id || 'No aplica'}</li>
       </ul>
@@ -173,7 +175,7 @@ const enviarEmailNotificacionAdminNuevaSolicitud = async (reserva, adminEmail) =
     const mailOptions = {
       from: `"Notificaciones Apialan" <${process.env.EMAIL_USER}>`,
       to: adminEmail, // Enviar al correo del administrador
-      subject: `📢 Nueva Solicitud de Reserva Recibida - ID: ${reserva.id}`,
+      subject: `Nueva Solicitud de Reserva Recibida - ID: ${reserva.id}`, // Emoji eliminado por si causa problemas
       html: detallesReserva,
     };
 


### PR DESCRIPTION
…dísticas

- Actualiza la plantilla de correo de notificación al administrador para mostrar correctamente el desglose de costos (neto, IVA, total) utilizando los campos históricos, solucionando el error $NaN.
- Corrige las consultas en la ruta GET /admin/stats para utilizar 'costo_total_historico' en lugar de 'costo_total', solucionando errores 500 al calcular ingresos.