### PR TITLE
feat: Implementar campos de facturación en reservas

### DIFF
--- a/routes/reservas.routes.js
+++ b/routes/reservas.routes.js
@@ -56,7 +56,14 @@ router.get('/', async (req, res) => {
 // ----------------------------------------------------------------
 router.post('/', async (req, res) => {
   try {
-    const { espacio_id, cliente_nombre, cliente_email, cliente_telefono, fecha_reserva: fecha_reserva_input, hora_inicio, hora_termino, notas_adicionales, rut_socio } = req.body;
+    const {
+      espacio_id, cliente_nombre, cliente_email, cliente_telefono,
+      fecha_reserva: fecha_reserva_input, hora_inicio, hora_termino,
+      notas_adicionales, rut_socio,
+      // Nuevos campos de facturación
+      tipo_documento, facturacion_rut, facturacion_razon_social,
+      facturacion_direccion, facturacion_giro
+    } = req.body;
 
     // Validate and format fecha_reserva_input
     let fecha_reserva_cleaned;
@@ -120,15 +127,26 @@ router.post('/', async (req, res) => {
         espacio_id, cliente_nombre, cliente_email, cliente_telefono,
         fecha_reserva, hora_inicio, hora_termino,
         costo_neto_historico, costo_iva_historico, costo_total_historico,
-        notas_adicionales, socio_id
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        notas_adicionales, socio_id,
+        -- Campos de facturación
+        tipo_documento, facturacion_rut, facturacion_razon_social,
+        facturacion_direccion, facturacion_giro
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
       RETURNING *;
     `;
     const values = [
       espacio_id, cliente_nombre, cliente_email, cliente_telefono,
       fecha_reserva_cleaned, hora_inicio, hora_termino,
-      desgloseCostos.neto, desgloseCostos.iva, desgloseCostos.total, // Usar los valores del desglose
-      notas_adicionales, socioId
+      desgloseCostos.neto, desgloseCostos.iva, desgloseCostos.total,
+      notas_adicionales, socioId,
+      // Valores para los nuevos campos de facturación
+      // Si tipo_documento es 'boleta' o no se proporciona, los campos de factura deben ser null.
+      // El frontend debería enviar null o no enviar los campos de factura si no son necesarios.
+      tipo_documento,
+      tipo_documento === 'factura' ? facturacion_rut : null,
+      tipo_documento === 'factura' ? facturacion_razon_social : null,
+      tipo_documento === 'factura' ? facturacion_direccion : null,
+      tipo_documento === 'factura' ? facturacion_giro : null
     ];
     const resultado = await pool.query(nuevaReservaQuery, values);
     const reservaCreada = resultado.rows[0];

--- a/scripts/migracion_facturacion.sql
+++ b/scripts/migracion_facturacion.sql
@@ -1,0 +1,9 @@
+-- Añadir columnas para información de facturación a la tabla 'reservas'
+-- Todas las columnas permiten valores NULL según el requerimiento.
+
+ALTER TABLE reservas
+ADD COLUMN tipo_documento VARCHAR(10),      -- Para 'boleta' o 'factura'
+ADD COLUMN facturacion_rut VARCHAR(20),       -- RUT para la factura
+ADD COLUMN facturacion_razon_social VARCHAR(255), -- Razón Social para la factura
+ADD COLUMN facturacion_direccion TEXT,        -- Dirección de facturación
+ADD COLUMN facturacion_giro VARCHAR(255);     -- Giro comercial para la factura

--- a/services/email.service.js
+++ b/services/email.service.js
@@ -169,6 +169,19 @@ const enviarEmailNotificacionAdminNuevaSolicitud = async (reserva, adminEmail) =
         <li><strong>Notas Adicionales:</strong> ${reserva.notas_adicionales || 'Ninguna'}</li>
         <li><strong>Socio ID:</strong> ${reserva.socio_id || 'No aplica'}</li>
       </ul>
+      ${ reserva.tipo_documento ? `
+      <hr>
+      <h3>Información de Facturación:</h3>
+      <ul>
+        <li><strong>Tipo Documento:</strong> ${reserva.tipo_documento}</li>
+        ${ reserva.tipo_documento === 'factura' ? `
+        <li><strong>RUT Facturación:</strong> ${reserva.facturacion_rut || 'No especificado'}</li>
+        <li><strong>Razón Social:</strong> ${reserva.facturacion_razon_social || 'No especificado'}</li>
+        <li><strong>Dirección Facturación:</strong> ${reserva.facturacion_direccion || 'No especificado'}</li>
+        <li><strong>Giro:</strong> ${reserva.facturacion_giro || 'No especificado'}</li>
+        ` : '' }
+      </ul>
+      ` : '' }
       <p>Por favor, revisa el panel de administración para más detalles o para confirmar la reserva una vez recibido el pago.</p>
     `;
 


### PR DESCRIPTION
- Añade columnas a la tabla 'reservas' para almacenar información de facturación (tipo_documento, RUT, razón social, dirección, giro).
  - Script 'scripts/migracion_facturacion.sql' creado para estos cambios de BD.
- Actualiza el endpoint POST /reservas para aceptar y guardar los datos de facturación.
- Los datos de facturación ahora se incluyen en el correo de notificación de nueva reserva para el administrador.
- Las rutas GET de administración de reservas incluirán automáticamente los nuevos campos.