### PR TITLE
fix: Filtrar reservas por estado en gráfico 'Reservas por Salón'

### DIFF
--- a/routes/admin.routes.js
+++ b/routes/admin.routes.js
@@ -165,7 +165,14 @@ router.get('/stats', async (req, res) => {
     const ingresosMesQuery = pool.query(`SELECT SUM(costo_total_historico) as total FROM "reservas" WHERE estado_reserva IN ('confirmada', 'pagado') AND DATE_TRUNC('month', fecha_reserva) = DATE_TRUNC('month', CURRENT_DATE)`);
 
     // Consultas para los Gráficos
-    const reservasPorSalonQuery = pool.query(`SELECT e.nombre, COUNT(r.id) as cantidad FROM "reservas" r JOIN "espacios" e ON r.espacio_id = e.id GROUP BY e.nombre`);
+    // Añadido filtro de estado_reserva para contar solo 'confirmada', 'pagado', 'pendiente_pago'
+    const reservasPorSalonQuery = pool.query(`
+      SELECT e.nombre, COUNT(r.id) as cantidad
+      FROM "reservas" r
+      JOIN "espacios" e ON r.espacio_id = e.id
+      WHERE r.estado_reserva IN ('confirmada', 'pagado', 'pendiente_pago')
+      GROUP BY e.nombre
+    `);
     // Actualizado a costo_total_historico
     const ingresosMesesQuery = pool.query(`SELECT TO_CHAR(DATE_TRUNC('month', fecha_reserva), 'YYYY-MM') as mes, SUM(costo_total_historico) as ingresos FROM "reservas" WHERE fecha_reserva >= DATE_TRUNC('month', CURRENT_DATE) - INTERVAL '5 months' AND estado_reserva IN ('confirmada', 'pagado') GROUP BY DATE_TRUNC('month', fecha_reserva) ORDER BY mes ASC`);
     


### PR DESCRIPTION
Modifica la consulta para el gráfico 'Reservas por Salón' en la ruta GET /admin/stats para que solo cuente las reservas cuyo estado sea 'confirmada', 'pagado' o 'pendiente_pago', excluyendo así las canceladas y proporcionando una visión más precisa de la ocupación o demanda.