### PR TITLE
fix: Corregir SyntaxError en POST /reservas

### DIFF
--- a/routes/reservas.routes.js
+++ b/routes/reservas.routes.js
@@ -114,7 +114,7 @@ router.post('/', async (req, res) => {
       isSocioBooking = true;
     }
 
-    }
+    // SE ELIMINÓ UNA LLAVE DE CIERRE '}' EXTRA AQUÍ
 
     let montoDescuentoReal = 0;
     let idCuponParaGuardar = cupon_aplicado_id; // Usar el id que viene del frontend si se valida


### PR DESCRIPTION
Elimina una llave de cierre '}' extra que causaba un error 'Missing catch or finally after try' en la ruta de creación de reservas, lo que impedía el correcto despliegue y funcionamiento de la API.