### PR TITLE
fix: Resolve SyntaxError in PUT /cupones/:id

### DIFF
--- a/routes/cupones.routes.js
+++ b/routes/cupones.routes.js
@@ -271,20 +271,10 @@ router.put('/:id', async (req, res) => {
   // ... más validaciones para fechas, etc. ...
 
   try {
-    // Construir la query dinámicamente
-    const fieldsToUpdate = {};
-    if (codigo !== undefined) fieldsToUpdate.codigo = codigo.toUpperCase();
-    if (tipo_descuento !== undefined) fieldsToUpdate.tipo_descuento = tipo_descuento;
-    if (valor_descuento !== undefined) fieldsToUpdate.valor_descuento = valor_descuento;
-    if (fecha_validez_desde !== undefined) fieldsToUpdate.fecha_validez_desde = fecha_validez_desde || null;
-    if (fecha_validez_hasta !== undefined) fieldsToUpdate.fecha_validez_hasta = fecha_validez_hasta || null;
-    if (usos_maximos !== undefined) fieldsToUpdate.usos_maximos = usos_maximos || null;
-    if (monto_minimo_reserva_neto !== undefined) fieldsToUpdate.monto_minimo_reserva_neto = monto_minimo_reserva_neto || 0;
-    // Construir la query dinámicamente
-    const fieldsToUpdate = {}; // Objeto para los campos que SÍ usan parámetros
-    const directSetClauses = ["fecha_actualizacion = CURRENT_TIMESTAMP"]; // Cláusulas directas
+    const fieldsToUpdate = {}; // ÚNICA declaración de los campos que vienen del body
+    const directSetClauses = ["fecha_actualizacion = CURRENT_TIMESTAMP"];
 
-    // Llenar fieldsToUpdate solo con los campos que vienen del req.body y usan parámetros
+    // Llenar fieldsToUpdate con los campos que vienen del req.body
     if (codigo !== undefined) fieldsToUpdate.codigo = codigo.toUpperCase();
     if (tipo_descuento !== undefined) fieldsToUpdate.tipo_descuento = tipo_descuento;
     if (valor_descuento !== undefined) fieldsToUpdate.valor_descuento = valor_descuento;
@@ -296,7 +286,7 @@ router.put('/:id', async (req, res) => {
     if (activo !== undefined) fieldsToUpdate.activo = activo;
     if (usos_actuales !== undefined) fieldsToUpdate.usos_actuales = usos_actuales;
 
-    // Construir las cláusulas SET parametrizadas
+    // Construir las cláusulas SET parametrizadas (a partir del único fieldsToUpdate)
     const parametrizedSetClauses = Object.keys(fieldsToUpdate).map((key, index) =>
       `${key} = $${index + 1}`
     );
@@ -304,12 +294,15 @@ router.put('/:id', async (req, res) => {
     const allSetClauses = [...directSetClauses, ...parametrizedSetClauses];
 
     if (Object.keys(fieldsToUpdate).length === 0) {
+      // No hay campos del body para actualizar, solo se actualizaría fecha_actualizacion.
+      // Se podría permitir o devolver un error si se prefiere que siempre haya un cambio del body.
+      // La lógica anterior devolvía error:
       return res.status(400).json({ error: 'No se proporcionaron campos (aparte de la fecha de actualización automática) para actualizar.' });
     }
 
     const finalSetClause = allSetClauses.join(', ');
-    const values = Object.values(fieldsToUpdate); // Solo los valores para los parámetros $N
-    values.push(id); // Para el WHERE id = ...
+    const values = Object.values(fieldsToUpdate);
+    values.push(id);
 
     const query = `UPDATE cupones SET ${finalSetClause} WHERE id = $${values.length} RETURNING *`;
 


### PR DESCRIPTION
Corrected a SyntaxError caused by a duplicate declaration of the 'fieldsToUpdate' variable in the PUT /cupones/:id endpoint.

The logic for constructing the SET clause has been streamlined to ensure `fecha_actualizacion = CURRENT_TIMESTAMP` is correctly included as direct SQL, while other fields from the request body are properly parameterized. This also re-confirms the fix for the original 'invalid input syntax for type timestamp' error.