### PR TITLE
Adjust blocked-dates route to be /blocked-dates

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ app.use('/auth', authRouter);
 app.use('/admin', adminRouter);
 app.use('/socios', sociosRouter);
 app.use('/cupones', cuponesRouter); // Usar rutas de cupones
-app.use('/api/blocked-dates', blockedDatesRouter); // Usar rutas de fechas bloqueadas
+app.use('/blocked-dates', blockedDatesRouter); // CORREGIDO: Usar rutas de fechas bloqueadas sin /api
 
 // Ruta de bienvenida
 app.get('/', (req, res) => {


### PR DESCRIPTION
Removes the /api prefix from the blocked-dates route registration in index.js to align with the frontend's API calling convention, assuming VITE_API_URL does not include /api.