### PR TITLE
feat: Extender la duración de la sesión para administradores

### DIFF
--- a/routes/auth.routes.js
+++ b/routes/auth.routes.js
@@ -93,10 +93,13 @@ router.post('/login', loginLimiter, async (req, res) => {
       rol: admin.rol
     };
     
+    // Definir la duración del token basado en el rol
+    const expiresIn = admin.rol === 'admin' ? '365d' : '8h'; // 365 días para admin, 8 horas para otros
+
     const token = jwt.sign(
-      payload, 
+      payload,
       process.env.JWT_SECRET, // Necesitaremos esta variable de entorno
-      { expiresIn: '8h' } // El token expirará en 8 horas
+      { expiresIn: expiresIn }
     );
 
     res.status(200).json({


### PR DESCRIPTION
Modifica la lógica de inicio de sesión para extender la duración del token JWT a 365 días para los usuarios con el rol de 'admin'.

Para otros roles, la duración del token permanece en 8 horas.

Esto aborda el requisito de que los administradores permanezcan conectados por más tiempo sin afectar a otros usuarios.