### PR TITLE
fix: Asegurar que unit_price sea un entero

### DIFF
--- a/routes/pagos.routes.js
+++ b/routes/pagos.routes.js
@@ -29,7 +29,7 @@ router.post('/crear-preferencia', async (req, res) => {
           id: reservaId,
           title: titulo,
           quantity: 1,
-          unit_price: Number(precio),
+          unit_price: parseInt(precio, 10),
           currency_id: 'CLP', // OJO: Cambiar a la moneda de tu país si no es CLP
         },
       ],


### PR DESCRIPTION
Convierte el `unit_price` a un entero usando `parseInt()` antes de enviarlo a la API de Mercado Pago.

Esto soluciona el error `unit_price must be a integer` que ocurría cuando el precio se enviaba como un número flotante.