### PR TITLE
fix(pagos): Corrige el manejo de decimales en los montos de pago

### DIFF
--- a/routes/pagos.routes.js
+++ b/routes/pagos.routes.js
@@ -29,7 +29,7 @@ router.post('/crear-preferencia', async (req, res) => {
           id: reservaId,
           title: titulo,
           quantity: 1,
-          unit_price: parseInt(precio, 10),
+          unit_price: parseFloat(precio),
           currency_id: 'CLP', // OJO: Cambiar a la moneda de tu país si no es CLP
         },
       ],

--- a/services/booking.service.js
+++ b/services/booking.service.js
@@ -132,20 +132,13 @@ const calcularDesgloseCostos = (
   const costoIvaCalculado = netoFinalParaIVACalculado * TASA_IVA;
   const costoTotalCalculado = netoFinalParaIVACalculado + costoIvaCalculado;
 
-  // DEBUG: Añadir un log para ver los valores calculados y redondeados.
-  const roundedValues = {
-    iva: Math.round(costoIvaCalculado),
-    total: Math.round(costoTotalCalculado),
-  };
-  console.log('[DEBUG] Valores calculados y redondeados:', roundedValues);
-
   // Redondear los valores finales para el usuario, pero mantener la precisión para los cálculos base.
   return {
     costoNetoBase: parseFloat(costoNetoBaseCalculado.toFixed(2)), // Precisión para la BD
     montoDescuentoAplicado: parseFloat(descuentoRealAplicado.toFixed(2)),
     netoFinalParaIVA: parseFloat(netoFinalParaIVACalculado.toFixed(2)), // Base para el IVA, con precisión
-    iva: roundedValues.iva, // Usar el valor redondeado
-    total: roundedValues.total, // Usar el valor redondeado
+    iva: parseFloat(costoIvaCalculado.toFixed(2)), // Usar el valor redondeado
+    total: parseFloat(costoTotalCalculado.toFixed(2)), // Usar el valor redondeado
   };
 };
 


### PR DESCRIPTION
Se identificó un problema que causaba que los pagos con tarjeta de crédito fueran rechazados. La causa principal era el manejo incorrecto de valores monetarios en dos áreas clave del sistema:

1.  **Servicio de Reservas (`booking.service.js`):** La función `calcularDesgloseCostos` redondeaba los montos de IVA y el total final a números enteros usando `Math.round()`. Esto eliminaba la precisión decimal necesaria para los valores monetarios.

2.  **Ruta de Pagos (`pagos.routes.js`):** Al crear la preferencia de pago en Mercado Pago, el precio total de la reserva se convertía a un entero usando `parseInt()`. Esto truncaba cualquier decimal, enviando un monto incorrecto a la pasarela de pago.

Este commit corrige ambos problemas:

-   En `booking.service.js`, se eliminó el redondeo con `Math.round()` y ahora se utiliza `parseFloat(value.toFixed(2))` para asegurar que los totales se calculen y devuelvan con dos decimales de precisión.
-   En `pagos.routes.js`, se reemplazó `parseInt()` por `parseFloat()` para que el `unit_price` enviado a Mercado Pago sea un número flotante, tal como lo requiere su API.

Estos cambios aseguran que los montos de las transacciones se manejen de manera consistente y precisa a lo largo de todo el flujo, desde el cálculo de costos hasta la creación del pago, solucionando así la causa de los rechazos de pago.