### PR TITLE
fix: Mejorar mensaje de error en validación de pagos

### DIFF
--- a/routes/pagos.routes.js
+++ b/routes/pagos.routes.js
@@ -163,9 +163,14 @@ router.post('/procesar-pago', async (req, res) => {
       reservaId
     } = req.body;
 
-    if (!token || !transaction_amount || !installments || !payment_method_id || !payer || !reservaId) {
-      return res.status(400).json({ error: 'Faltan datos requeridos para procesar el pago.' });
-    }
+    // Validación de entrada más específica para mejor depuración
+    if (!token) return res.status(400).json({ error: 'El campo "token" es requerido.' });
+    if (!transaction_amount) return res.status(400).json({ error: 'El campo "transaction_amount" es requerido.' });
+    if (installments == null) return res.status(400).json({ error: 'El campo "installments" es requerido.' });
+    if (!payment_method_id) return res.status(400).json({ error: 'El campo "payment_method_id" es requerido.' });
+    if (!payer) return res.status(400).json({ error: 'El objeto "payer" es requerido.' });
+    if (!reservaId) return res.status(400).json({ error: 'El campo "reservaId" es requerido.' });
+
 
     const payment_data = {
       transaction_amount: Number(transaction_amount),

--- a/test/pagos.test.js
+++ b/test/pagos.test.js
@@ -326,14 +326,14 @@ describe('Rutas de Pagos - /pagos', () => {
       });
     });
 
-    it('debería retornar 400 si faltan datos en la solicitud', async () => {
-      const { reservaId, ...incompleteRequest } = mockPaymentRequest;
+    it('debería retornar 400 si falta el token en la solicitud', async () => {
+      const { token, ...incompleteRequest } = mockPaymentRequest;
       const response = await request(app)
         .post('/pagos/procesar-pago')
         .send(incompleteRequest);
 
       expect(response.status).toBe(400);
-      expect(response.body.error).toBe('Faltan datos requeridos para procesar el pago.');
+      expect(response.body.error).toBe('El campo "token" es requerido.');
     });
   });
 });


### PR DESCRIPTION
Se ha mejorado la validación en el endpoint `POST /pagos/procesar-pago` para que devuelva un mensaje de error específico que indique qué campo falta en la solicitud.

Anteriormente, devolvía un error genérico "Faltan datos requeridos para procesar el pago.", lo que dificultaba la depuración en el frontend.

Ahora, si falta un campo como el token, el error será "El campo \"token\" es requerido.", facilitando la identificación del problema.

Se ha actualizado la suite de pruebas para verificar este nuevo comportamiento.