### PR TITLE
feat: Enviar email de notificación al admin en pagos exitosos

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -22,3 +22,4 @@ EMAIL_PASS="test_password"
 EMAIL_HOST="smtp.example.com"
 EMAIL_PORT=587
 EMAIL_FROM='"Test Service" <test@example.com>'
+ADMIN_EMAIL="admin@example.com"


### PR DESCRIPTION
Se ha modificado la lógica de confirmación de pagos para que, además de enviar el correo de confirmación al cliente, también se envíe una notificación de nueva reserva al correo del administrador.

- Se ha actualizado la función auxiliar `confirmarReservaYEnviarEmail` en `routes/pagos.routes.js` para incluir la llamada a `enviarEmailNotificacionAdminNuevaSolicitud`.
- Esta mejora se aplica tanto a los pagos procesados por el webhook como a los pagos con tarjeta a través del endpoint `/procesar-pago`.
- Se han actualizado las pruebas para verificar que ambos correos (cliente y administrador) son enviados correctamente.