### PR TITLE
fix: Configure CORS to allow frontend origin

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,18 +19,8 @@ const whitelist = [
 ];
 
 const corsOptions = {
-  origin: function (origin, callback) {
-    // Log para depurar el valor de origin que llega al backend
-    console.log('CORS check: Request origin:', origin);
-    console.log('CORS whitelist:', whitelist);
-    if (whitelist.includes(origin) || !origin) {
-      console.log('CORS check: Origin PERMITIDO.');
-      callback(null, true);
-    } else {
-      console.log('CORS check: Origin DENEGADO.');
-      callback(new Error('No permitido por la política de CORS'));
-    }
-  }
+  origin: whitelist,
+  optionsSuccessStatus: 200 // For legacy browser support
 };
 
 app.use(cors(corsOptions));


### PR DESCRIPTION
This commit resolves a CORS issue that was blocking the frontend application from making requests to the API.

The custom `origin` function in the CORS configuration in `index.js` has been replaced with the standard whitelist array method. This is a more robust and standard way to handle CORS whitelists and ensures that requests from the production frontend URL (`https://reservas-oficinas-apialan.vercel.app`) are allowed.