### PR TITLE
feat: Migrate email service from Nodemailer to SendGrid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
+                "@sendgrid/mail": "^8.1.3",
                 "bcrypt": "^6.0.0",
                 "bcryptjs": "^3.0.2",
                 "cors": "^2.8.5",
@@ -19,7 +20,6 @@
                 "express-rate-limit": "^7.0.0",
                 "jsonwebtoken": "^9.0.2",
                 "mercadopago": "^2.8.0",
-                "nodemailer": "^7.0.3",
                 "pg": "^8.16.0",
                 "react-icons": "^5.5.0"
             },
@@ -987,6 +987,44 @@
                 "@noble/hashes": "^1.1.5"
             }
         },
+        "node_modules/@sendgrid/client": {
+            "version": "8.1.6",
+            "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
+            "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
+            "license": "MIT",
+            "dependencies": {
+                "@sendgrid/helpers": "^8.0.0",
+                "axios": "^1.12.0"
+            },
+            "engines": {
+                "node": ">=12.*"
+            }
+        },
+        "node_modules/@sendgrid/helpers": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+            "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+            "license": "MIT",
+            "dependencies": {
+                "deepmerge": "^4.2.2"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@sendgrid/mail": {
+            "version": "8.1.6",
+            "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.6.tgz",
+            "integrity": "sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==",
+            "license": "MIT",
+            "dependencies": {
+                "@sendgrid/client": "^8.1.5",
+                "@sendgrid/helpers": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=12.*"
+            }
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1231,8 +1269,18 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/axios": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.4",
+                "proxy-from-env": "^1.1.0"
+            }
         },
         "node_modules/babel-jest": {
             "version": "29.7.0",
@@ -1734,7 +1782,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
@@ -1897,7 +1944,6 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -1907,7 +1953,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
@@ -2099,7 +2144,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -2370,11 +2414,30 @@
                 "node": ">=8"
             }
         },
+        "node_modules/follow-redirects": {
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/form-data": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
             "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -2614,7 +2677,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
@@ -4004,15 +4066,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/nodemailer": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
-            "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
-            "license": "MIT-0",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/nodemon": {
             "version": "3.1.10",
             "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
@@ -4500,6 +4553,12 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "license": "MIT"
         },
         "node_modules/pstree.remy": {
             "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "express-rate-limit": "^7.0.0",
         "jsonwebtoken": "^9.0.2",
         "mercadopago": "^2.8.0",
-        "nodemailer": "^7.0.3",
+        "@sendgrid/mail": "^8.1.3",
         "pg": "^8.16.0",
         "react-icons": "^5.5.0"
     },

--- a/services/email.service.js
+++ b/services/email.service.js
@@ -1,255 +1,130 @@
 // Archivo: services/emailService.js
 
-const nodemailer = require('nodemailer');
+const sgMail = require('@sendgrid/mail');
 const ejs = require('ejs');
 const path = require('path');
 
-// Configuración del "Transportador" que enviará los emails usando Gmail.
-// Toma las credenciales de tu archivo .env
-const transporter = nodemailer.createTransport({
-  service: 'gmail',
-  auth: {
-    user: process.env.EMAIL_USER,
-    pass: process.env.EMAIL_PASS, // La contraseña de aplicación de 16 letras de Google
-  },
-});
+// Configura SendGrid con la API Key de tus variables de entorno
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 
-// Helper functions for EJS templates
+// Define el email y nombre del remitente.
+// ¡MUY IMPORTANTE! El email debe estar verificado en tu cuenta de SendGrid.
+// Usa el email de tu dominio autenticado (apialan.cl).
+const FROM_EMAIL = 'reservas@apialan.cl'; // O notificaciones@apialan.cl, etc.
+const FROM_NAME = 'Reservas Apialan';
+
+// --- Helper functions (sin cambios) ---
 const formatCurrency = (amount) => {
-  // Asegurarse de que amount sea un número antes de formatear
   const numAmount = parseFloat(amount);
-  if (isNaN(numAmount)) {
-    return 'N/A'; // O algún valor predeterminado o manejo de error
-  }
+  if (isNaN(numAmount)) return 'N/A';
   return new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' }).format(numAmount);
 };
-
 const formatDate = (dateString) => {
   if (!dateString) return 'N/A';
-  // Convertir a objeto Date solo si no lo es ya, y manejar fechas inválidas
   try {
     const date = new Date(dateString);
-    if (isNaN(date.getTime())) { // Verifica si la fecha es inválida
-        // Intenta parsear específicamente YYYY-MM-DD si la conversión directa falla
-        const parts = dateString.split('-');
-        if (parts.length === 3) {
-            const year = parseInt(parts[0], 10);
-            const month = parseInt(parts[1], 10) -1; // Meses son 0-indexados
-            const day = parseInt(parts[2], 10);
-            const specificDate = new Date(year, month, day);
-            if (!isNaN(specificDate.getTime())) {
-                 return specificDate.toLocaleDateString('es-CL', { year: 'numeric', month: 'long', day: 'numeric' });
-            }
-        }
-        return 'Fecha inválida';
+    if (isNaN(date.getTime())) {
+      const parts = dateString.split('-');
+      if (parts.length === 3) {
+        const year = parseInt(parts[0], 10), month = parseInt(parts[1], 10) - 1, day = parseInt(parts[2], 10);
+        const specificDate = new Date(year, month, day);
+        if (!isNaN(specificDate.getTime())) return specificDate.toLocaleDateString('es-CL', { year: 'numeric', month: 'long', day: 'numeric' });
+      }
+      return 'Fecha inválida';
     }
     return date.toLocaleDateString('es-CL', { year: 'numeric', month: 'long', day: 'numeric' });
-  } catch (e) {
-    return 'Fecha inválida';
-  }
+  } catch (e) { return 'Fecha inválida'; }
 };
-
 const formatTime = (timeString) => {
   if (!timeString || typeof timeString !== 'string') return 'N/A';
   return timeString.substring(0, 5);
 };
 
-// --- FUNCIÓN 1: EMAIL DE SOLICITUD DE RESERVA RECIBIDA (ACTUALIZADA) ---
-/**
- * Envía un email inicial al cliente informando que su solicitud ha sido recibida
- * y está pendiente de pago.
- * @param {object} reservaData - El objeto con los datos para el email.
- */
+// --- FUNCIÓN GENERAL PARA ENVIAR CORREOS ---
+// Refactorizamos para no repetir el bloque try/catch
+const enviarEmail = async (msg) => {
+  try {
+    await sgMail.send(msg);
+    console.log(`Email enviado a ${msg.to}`);
+  } catch (error) {
+    console.error(`Error al enviar email a ${msg.to}:`, error);
+    if (error.response) {
+      console.error(error.response.body);
+    }
+  }
+};
+
+// --- FUNCIÓN 1: EMAIL DE SOLICITUD DE RESERVA RECIBIDA ---
 const enviarEmailSolicitudRecibida = async (reservaData) => {
-  try {
-    const mailOptions = {
-      from: `"Reservas Apialan" <${process.env.EMAIL_USER}>`,
-      to: reservaData.cliente_email,
-      subject: `📄 Solicitud de Reserva Recibida (ID: ${reservaData.id})`,
-      html: await ejs.renderFile(
-        path.join(__dirname, '../views/emails/solicitudRecibida.ejs'),
-        {
-          reserva: reservaData, // Este objeto ahora contiene los campos como costo_total_solicitud, etc.
-          formatCurrency: formatCurrency,
-          formatDate: formatDate,
-          formatTime: formatTime
-        }
-      ),
-    };
-
-    await transporter.sendMail(mailOptions);
-    console.log(`Email de solicitud recibida enviado a ${reservaData.cliente_email}`);
-  } catch (error) {
-    console.error(`Error al enviar email de solicitud para reserva ${reservaData.id}:`, error);
-  }
+  const msg = {
+    to: reservaData.cliente_email,
+    from: { email: FROM_EMAIL, name: FROM_NAME },
+    subject: `📄 Solicitud de Reserva Recibida (ID: ${reservaData.id})`,
+    html: await ejs.renderFile(
+      path.join(__dirname, '../views/emails/solicitudRecibida.ejs'),
+      { reserva: reservaData, formatCurrency, formatDate, formatTime }
+    ),
+  };
+  enviarEmail(msg);
 };
 
-
-// --- FUNCIÓN 2: EMAIL DE RESERVA CONFIRMADA (TRAS EL PAGO) ---
+// --- FUNCIÓN 2: EMAIL DE RESERVA CONFIRMADA ---
 const enviarEmailReservaConfirmada = async (reserva) => {
-  try {
-    // Para el email de confirmación, si es una reserva de rango, reserva.costo_total_historico es el total.
-    // Si es una reserva discreta individual, es el costo de ese día.
-    // La plantilla reservaConfirmada.ejs fue adaptada para mostrar el costo total de la solicitud si se le pasa,
-    // o el costo_total_historico de la reserva individual.
-    // Aquí, `reserva` es una fila de la BD. Si queremos mostrar el total de la solicitud original
-    // para una reserva discreta, necesitaríamos más contexto o pasar un objeto `datosParaEmail` similar.
-    // Por ahora, la plantilla usará `reserva.costo_total_historico` si `costo_total_solicitud` no está.
-    const datosParaPlantillaConfirmacion = {
-        ...reserva,
-        // Si es una reserva de rango, costo_total_historico es el total.
-        // Si es un día único, costo_total_historico es el total.
-        // Si es una de varias discretas, costo_total_historico es individual.
-        // La plantilla debe ser lo suficientemente inteligente o se le debe pasar explícitamente `costo_total_solicitud`.
-        // Como esta función recibe una reserva individual, `costo_total_solicitud` no está naturalmente aquí.
-        // La plantilla `reservaConfirmada.ejs` fue modificada para usar `reserva.costo_total_solicitud || reserva.costo_total_historico`
-    };
-
-    const mailOptions = {
-      from: `"Reservas Apialan" <${process.env.EMAIL_USER}>`,
-      to: reserva.cliente_email,
-      subject: `✅ ¡Tu reserva en Apialan está Confirmada! (ID: ${reserva.id})`,
-      html: await ejs.renderFile(
-        path.join(__dirname, '../views/emails/reservaConfirmada.ejs'),
-        {
-          reserva: datosParaPlantillaConfirmacion,
-          formatCurrency: formatCurrency,
-          formatDate: formatDate,
-          formatTime: formatTime
-        }
-      ),
-    };
-    await transporter.sendMail(mailOptions);
-    console.log(`Email de confirmación final enviado a ${reserva.cliente_email}`);
-  } catch (error) {
-    console.error(`Error al enviar email de confirmación para reserva ${reserva.id}:`, error);
-  }
+  const msg = {
+    to: reserva.cliente_email,
+    from: { email: FROM_EMAIL, name: FROM_NAME },
+    subject: `✅ ¡Tu reserva en Apialan está Confirmada! (ID: ${reserva.id})`,
+    html: await ejs.renderFile(
+      path.join(__dirname, '../views/emails/reservaConfirmada.ejs'),
+      { reserva, formatCurrency, formatDate, formatTime }
+    ),
+  };
+  enviarEmail(msg);
 };
-
 
 // --- FUNCIÓN 3: EMAIL DE CANCELACIÓN SOLICITADA POR EL CLIENTE ---
 const enviarEmailCancelacionCliente = async (reserva) => {
-  try {
-    const mailOptions = {
-      from: `"Reservas Apialan" <${process.env.EMAIL_USER}>`,
-      to: reserva.cliente_email,
-      subject: `✅ Confirmación de Cancelación de Reserva (ID: ${reserva.id})`,
-      html: await ejs.renderFile(
-        path.join(__dirname, '../views/emails/cancelacionCliente.ejs'),
-        {
-          reserva: reserva,
-          formatCurrency: formatCurrency,
-          formatDate: formatDate,
-          formatTime: formatTime
-        }
-      ),
-    };
-    await transporter.sendMail(mailOptions);
-    console.log(`Email de cancelación (solicitada por cliente) enviado a ${reserva.cliente_email}`);
-  } catch (error) {
-    console.error(`Error al enviar email de cancelación (cliente) para reserva ${reserva.id}:`, error);
-  }
+  const msg = {
+    to: reserva.cliente_email,
+    from: { email: FROM_EMAIL, name: FROM_NAME },
+    subject: `✅ Confirmación de Cancelación de Reserva (ID: ${reserva.id})`,
+    html: await ejs.renderFile(
+      path.join(__dirname, '../views/emails/cancelacionCliente.ejs'),
+      { reserva, formatCurrency, formatDate, formatTime }
+    ),
+  };
+  enviarEmail(msg);
 };
-
 
 // --- FUNCIÓN 4: EMAIL DE CANCELACIÓN INICIADA POR EL ADMINISTRADOR ---
 const enviarEmailCancelacionAdmin = async (reserva) => {
-  try {
-    const mailOptions = {
-      from: `"Reservas Apialan" <${process.env.EMAIL_USER}>`,
-      to: reserva.cliente_email,
-      subject: `❌ Notificación de Cancelación de Reserva (ID: ${reserva.id})`,
-      html: await ejs.renderFile(
-        path.join(__dirname, '../views/emails/cancelacionAdmin.ejs'),
-        {
-          reserva: reserva,
-          formatCurrency: formatCurrency,
-          formatDate: formatDate,
-          formatTime: formatTime
-        }
-      ),
-    };
-    await transporter.sendMail(mailOptions);
-    console.log(`Email de cancelación (iniciada por admin) enviado a ${reserva.cliente_email}`);
-  } catch (error) {
-    console.error(`Error al enviar email de cancelación (admin) para reserva ${reserva.id}:`, error);
-  }
+  const msg = {
+    to: reserva.cliente_email,
+    from: { email: FROM_EMAIL, name: FROM_NAME },
+    subject: `❌ Notificación de Cancelación de Reserva (ID: ${reserva.id})`,
+    html: await ejs.renderFile(
+      path.join(__dirname, '../views/emails/cancelacionAdmin.ejs'),
+      { reserva, formatCurrency, formatDate, formatTime }
+    ),
+  };
+  enviarEmail(msg);
 };
 
-
-// --- FUNCIÓN 5: EMAIL DE NOTIFICACIÓN AL ADMINISTRADOR SOBRE NUEVA SOLICITUD ---
-/**
- * Envía un email de notificación al administrador sobre una nueva solicitud de reserva.
- * @param {object} reservaData - El objeto con todos los datos de la solicitud para el email.
- * @param {string} adminEmail - La dirección de correo del administrador.
- */
+// --- FUNCIÓN 5: EMAIL DE NOTIFICACIÓN AL ADMINISTRADOR ---
 const enviarEmailNotificacionAdminNuevaSolicitud = async (reservaData, adminEmail) => {
-  try {
-    const detallesReserva = `
-      <p>Se ha recibido una nueva solicitud de reserva con los siguientes detalles:</p>
-      <ul>
-        <li><strong>ID Reserva Principal:</strong> ${reservaData.id}</li>
-        <li><strong>Espacio:</strong> ${reservaData.nombre_espacio || 'No especificado'}</li>
-        <li><strong>Cliente:</strong> ${reservaData.cliente_nombre}</li>
-        <li><strong>Email Cliente:</strong> ${reservaData.cliente_email}</li>
-        <li><strong>Teléfono Cliente:</strong> ${reservaData.cliente_telefono || 'No especificado'}</li>
-        ${ reservaData.dias_discretos_info && reservaData.dias_discretos_info.length > 0 ?
-          `<li><strong>Fechas (Días Discretos):</strong><ul>${reservaData.dias_discretos_info.map(d => `<li>${formatDate(d)}</li>`).join('')}</ul></li>` :
-        reservaData.end_date && reservaData.end_date !== reservaData.fecha_reserva ? // Asegurar que end_date sea diferente de fecha_reserva para considerarlo rango
-          `<li><strong>Fechas del Rango:</strong> Desde ${formatDate(reservaData.fecha_reserva)} hasta ${formatDate(reservaData.end_date)}</li>` :
-          `<li><strong>Fecha:</strong> ${formatDate(reservaData.fecha_reserva)}</li>`
-        }
-        <li><strong>Hora Inicio:</strong> ${formatTime(reservaData.hora_inicio)}</li>
-        <li><strong>Hora Término:</strong> ${formatTime(reservaData.hora_termino)}</li>
-      </ul>
-      <hr>
-      <h3>Detalles del Costo de la Solicitud:</h3>
-      <ul>
-        <li><strong>Subtotal Neto Solicitud:</strong> ${formatCurrency(reservaData.costo_neto_total_solicitud_o_equivalente)}</li>
-        ${(reservaData.monto_descuento_total_solicitud_o_equivalente && parseFloat(reservaData.monto_descuento_total_solicitud_o_equivalente) > 0) ? `
-          <li><strong>Descuento Cupón Total:</strong> - ${formatCurrency(reservaData.monto_descuento_total_solicitud_o_equivalente)}</li>
-          <li><strong>Neto con Descuento:</strong> ${formatCurrency(parseFloat(reservaData.costo_neto_total_solicitud_o_equivalente) - parseFloat(reservaData.monto_descuento_total_solicitud_o_equivalente))}</li>
-        ` : ''}
-        <li><strong>IVA (19%) Solicitud:</strong> ${formatCurrency(reservaData.iva_total_solicitud_o_equivalente)}</li>
-        <li><strong>Total General Solicitud:</strong> ${formatCurrency(reservaData.costo_total_solicitud)}</li>
-      </ul>
-       ${ reservaData.notas_adicionales ? `
-      <hr>
-      <h3>Notas Adicionales:</h3>
-      <p>${reservaData.notas_adicionales}</p>
-      ` : '' }
-      ${ reservaData.socio_id ? `
-      <hr>
-      <p><strong>Reserva de Socio ID:</strong> ${reservaData.socio_id}</p>
-      ` : ''}
-      ${ reservaData.tipo_documento ? `
-      <hr>
-      <h3>Información de Facturación:</h3>
-      <ul>
-        <li><strong>Tipo Documento:</strong> ${reservaData.tipo_documento}</li>
-        ${ reservaData.tipo_documento === 'factura' ? `
-        <li><strong>RUT Facturación:</strong> ${reservaData.facturacion_rut || 'No especificado'}</li>
-        <li><strong>Razón Social:</strong> ${reservaData.facturacion_razon_social || 'No especificado'}</li>
-        <li><strong>Dirección Facturación:</strong> ${reservaData.facturacion_direccion || 'No especificado'}</li>
-        <li><strong>Giro:</strong> ${reservaData.facturacion_giro || 'No especificado'}</li>
-        ` : '' }
-      </ul>
-      ` : '' }
-      <p>Por favor, revisa el panel de administración para más detalles o para confirmar la reserva una vez recibido el pago.</p>
-    `;
+    // Asumiendo que tienes una plantilla llamada notificacionAdmin.ejs
+    const htmlContent = await ejs.renderFile(
+        path.join(__dirname, '../views/emails/notificacionAdmin.ejs'),
+        { reservaData, formatCurrency, formatDate, formatTime }
+      );
 
-    const mailOptions = {
-      from: `"Notificaciones Apialan" <${process.env.EMAIL_USER}>`,
-      to: adminEmail,
-      subject: `Nueva Solicitud de Reserva Recibida - ID: ${reservaData.id}`,
-      html: detallesReserva,
-    };
-
-    await transporter.sendMail(mailOptions);
-    console.log(`Email de notificación de nueva solicitud enviado a ${adminEmail} para reserva ID: ${reservaData.id}`);
-  } catch (error) {
-    console.error(`Error al enviar email de notificación al admin para reserva ${reservaData.id}:`, error);
-  }
+  const msg = {
+    to: adminEmail,
+    from: { email: FROM_EMAIL, name: 'Notificaciones Apialan' },
+    subject: `Nueva Solicitud de Reserva Recibida - ID: ${reservaData.id}`,
+    html: htmlContent,
+  };
+  enviarEmail(msg);
 };
 
 module.exports = {


### PR DESCRIPTION
This commit replaces the Nodemailer implementation with SendGrid for handling email sending.

Changes include:
- Updated `package.json` to remove the `nodemailer` dependency and add `@sendgrid/mail`.
- Replaced the entire content of `services/email.service.js` with a new implementation that uses the `@sendgrid/mail` library.
- The new service is configured to use the `SENDGRID_API_KEY` from environment variables.