### PR TITLE
Fix: Correct Saturday pricing logic for 'Sala Pequeña'

### DIFF
--- a/services/booking.service.js
+++ b/services/booking.service.js
@@ -97,12 +97,12 @@ const calcularDesgloseCostos = (
   // Precios especiales para los sábados, usando nombres normalizados para más robustez
   const preciosSabado = {
     general: {
-      'sala chica': 12000,
+      'sala pequena': 12000,
       'sala mediana': 18000,
       'salon grande': 28000,
     },
     socio: {
-      'sala chica': 8000,
+      'sala pequena': 8000,
       'sala mediana': 10000,
       'salon grande': 12000,
     },
@@ -119,8 +119,12 @@ const calcularDesgloseCostos = (
       if (normalizedName.includes('sala mediana')) {
         return priceMap['sala mediana'];
       }
-      if (normalizedName.includes('sala chica')) {
-        return priceMap['sala chica'];
+      // Busca 'pequena' o 'chica' para máxima compatibilidad.
+      if (
+        normalizedName.includes('pequena') ||
+        normalizedName.includes('chica')
+      ) {
+        return priceMap['sala pequena'];
       }
       return null;
     };


### PR DESCRIPTION
This commit provides the definitive fix for the persistent Saturday pricing issue, which was narrowed down to the 'Sala Pequeña'.

The root cause was a naming mismatch between the database ('Sala Pequeña') and the identifier used in the code ('sala chica'). This prevented the special Saturday rate from being applied to that specific space.

This solution makes the price lookup logic more flexible and robust. It now checks for the presence of either 'pequena' or 'chica' in the normalized space name, ensuring the correct price is applied regardless of which synonym is used in the database. This resolves the issue definitively while maintaining compatibility.

The correct differential pricing logic for Saturdays is preserved:
- General customers are charged a total price per hour (VAT included).
- Members are charged a fixed net price per reservation.